### PR TITLE
Feat/#6_노션 상세 페이지 구현 및 생성 바텀시트 UI 연결

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,3 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  -ms-overflow-style: none;
+}
+::-webkit-scrollbar {
+  display: none;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,8 @@
+'use client';
+
+import RecentlyNotionContext from '@components/context/RecentlyNotionContext';
 import './globals.css';
+import Navigation from '@components/item/Navigation';
 
 export default function RootLayout({
   children,
@@ -8,9 +12,12 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body>
-        <div className="w-[95vw] sm:w-[90vw] md:w-[80vw] h-[90vh] mt-[5vh] m-auto ">
-          {children}
-        </div>
+        <RecentlyNotionContext>
+          <div className="w-[95vw] sm:w-[90vw] md:w-[80vw] h-[90vh] mt-[2vh] sm:mt-[5vh] m-auto ">
+            <Navigation />
+            {children}
+          </div>
+        </RecentlyNotionContext>
       </body>
     </html>
   );

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -1,39 +1,33 @@
 'use client';
 
-import React, { ReactNode, useState } from 'react';
+import { useRecentlyNotionContext } from '@components/context/RecentlyNotionContext';
 
-import BottomSheet from '@components/common/BottomSheet';
 import CircleLine from '@components/common/CircleLine';
 import Description from '@components/common/Description';
 import Title from '@components/common/Title';
 import NotionList from '@components/item/NotionList';
-import NotionForm from '@components/item/NotionForm';
 
 import { mockNotionBanana } from '@mocks/mockData/notionList';
 
-import { useRouter } from 'next/navigation';
-import { useRecentlyNotionContext } from '@components/context/RecentlyNotionContext';
-
-type Content = 'notionItemForm' | 'notionItemPlusMenu';
-
-const content: Record<Content, ReactNode> = {
-  notionItemForm: <NotionForm />,
-  notionItemPlusMenu: <></>,
-};
+import { useBottomSheetContent } from 'hooks/useBottomSheetContent';
+import { useMovePage } from 'hooks/useMovePage';
 
 export default function play({ params }: { params: { id: number } }) {
-  const router = useRouter();
   const { addNotionItem } = useRecentlyNotionContext();
-  const [bottomSheetContent, setBottomSheetContent] = useState<Content | null>(
-    null,
-  );
+  const { moveNotionItemPage } = useMovePage();
+
+  const {
+    handlePlusButtonClick,
+    handleMoreMenuButtonClick,
+    bottomSheetComponent,
+  } = useBottomSheetContent();
 
   //추후 fetch한 데이터로 수정
   const { id, name, description, relatedNotionList } = mockNotionBanana;
 
-  const moveNotionItemPage = (id: number) => {
+  const handleNotionItemClick = () => (id: number) => {
     addNotionItem({ id, name });
-    router.push(`/notion/${id}`, { scroll: true });
+    moveNotionItemPage(id);
   };
 
   return (
@@ -43,17 +37,11 @@ export default function play({ params }: { params: { id: number } }) {
       <Description content={description} />
       <NotionList
         notionList={relatedNotionList}
-        handlePlusButtonClick={() => setBottomSheetContent('notionItemForm')}
-        handleMoreMenuButtonClick={() =>
-          setBottomSheetContent('notionItemPlusMenu')
-        }
-        handleNotionItemClick={moveNotionItemPage}
+        handlePlusButtonClick={handlePlusButtonClick}
+        handleMoreMenuButtonClick={handleMoreMenuButtonClick}
+        handleNotionItemClick={() => handleNotionItemClick()}
       />
-      {bottomSheetContent && (
-        <BottomSheet closeEvent={() => setBottomSheetContent(null)}>
-          {content[bottomSheetContent]}
-        </BottomSheet>
-      )}
+      {bottomSheetComponent}
     </main>
   );
 }

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
-export default function play() {
+export default function play({ params }: { params: { id: number } }) {
   return <div>this is side page. </div>;
 }

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -1,5 +1,59 @@
-import React from 'react';
+'use client';
+
+import React, { ReactNode, useState } from 'react';
+
+import BottomSheet from '@components/common/BottomSheet';
+import CircleLine from '@components/common/CircleLine';
+import Description from '@components/common/Description';
+import Title from '@components/common/Title';
+import NotionList from '@components/item/NotionList';
+import NotionForm from '@components/item/NotionForm';
+
+import { mockNotionBanana } from '@mocks/mockData/notionList';
+
+import { useRouter } from 'next/navigation';
+import { useRecentlyNotionContext } from '@components/context/RecentlyNotionContext';
+
+type Content = 'notionItemForm' | 'notionItemPlusMenu';
+
+const content: Record<Content, ReactNode> = {
+  notionItemForm: <NotionForm />,
+  notionItemPlusMenu: <></>,
+};
 
 export default function play({ params }: { params: { id: number } }) {
-  return <div>this is side page. </div>;
+  const router = useRouter();
+  const { addNotionItem } = useRecentlyNotionContext();
+  const [bottomSheetContent, setBottomSheetContent] = useState<Content | null>(
+    null,
+  );
+
+  //추후 fetch한 데이터로 수정
+  const { id, name, description, relatedNotionList } = mockNotionBanana;
+
+  const moveNotionItemPage = (id: number) => {
+    addNotionItem({ id, name });
+    router.push(`/notion/${id}`, { scroll: true });
+  };
+
+  return (
+    <main className="flex flex-col gap-5">
+      <Title content={name} />
+      <CircleLine amount={8} />
+      <Description content={description} />
+      <NotionList
+        notionList={relatedNotionList}
+        handlePlusButtonClick={() => setBottomSheetContent('notionItemForm')}
+        handleMoreMenuButtonClick={() =>
+          setBottomSheetContent('notionItemPlusMenu')
+        }
+        handleNotionItemClick={moveNotionItemPage}
+      />
+      {bottomSheetContent && (
+        <BottomSheet closeEvent={() => setBottomSheetContent(null)}>
+          {content[bottomSheetContent]}
+        </BottomSheet>
+      )}
+    </main>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import BottomSheet from '@components/common/BottomSheet';
 import NotionForm from '@components/item/NotionForm';
 
 import { useRouter } from 'next/navigation';
+import { mockNotionBanana, mockNotionBear } from '@mocks/mockData/notionList';
 
 type Content = 'notionItemForm' | 'notionItemPlusMenu';
 
@@ -47,6 +48,10 @@ export default function Home() {
       <Title content="개념" />
       <CircleLine amount={8} />
       <NotionList
+        notionList={[
+          ...mockNotionBear.relatedNotionList,
+          ...mockNotionBanana.relatedNotionList,
+        ]}
         handlePlusButtonClick={() => setBottomSheetContent('notionItemForm')}
         handleMoreMenuButtonClick={() =>
           setBottomSheetContent('notionItemPlusMenu')

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,12 @@
 'use client';
 
-import { ReactNode, useEffect, useState } from 'react';
-import { worker } from '../mocks/worker';
-
 import NotionList from '@components/item/NotionList';
 import Title from '@components/common/Title';
 import CircleLine from '@components/common/CircleLine';
-import BottomSheet from '@components/common/BottomSheet';
-import NotionForm from '@components/item/NotionForm';
 
-import { useRouter } from 'next/navigation';
 import { mockNotionBanana, mockNotionBear } from '@mocks/mockData/notionList';
-
-type Content = 'notionItemForm' | 'notionItemPlusMenu';
-
-const content: Record<Content, ReactNode> = {
-  notionItemForm: <NotionForm />,
-  notionItemPlusMenu: <></>,
-};
+import { useBottomSheetContent } from 'hooks/useBottomSheetContent';
+import { useMovePage } from 'hooks/useMovePage';
 
 export default function Home() {
   // if (process.env.NODE_ENV === 'development') {
@@ -34,14 +23,13 @@ export default function Home() {
   //   })();
   // }, []);
 
-  const router = useRouter();
-  const [bottomSheetContent, setBottomSheetContent] = useState<Content | null>(
-    null,
-  );
+  const {
+    handlePlusButtonClick,
+    handleMoreMenuButtonClick,
+    bottomSheetComponent,
+  } = useBottomSheetContent();
 
-  const moveNotionItemPage = (id: number) => {
-    router.push(`/notion/${id}`, { scroll: true });
-  };
+  const { moveNotionItemPage } = useMovePage();
 
   return (
     <main className="flex flex-col gap-5">
@@ -52,17 +40,11 @@ export default function Home() {
           ...mockNotionBear.relatedNotionList,
           ...mockNotionBanana.relatedNotionList,
         ]}
-        handlePlusButtonClick={() => setBottomSheetContent('notionItemForm')}
-        handleMoreMenuButtonClick={() =>
-          setBottomSheetContent('notionItemPlusMenu')
-        }
+        handlePlusButtonClick={handlePlusButtonClick}
+        handleMoreMenuButtonClick={handleMoreMenuButtonClick}
         handleNotionItemClick={moveNotionItemPage}
       />
-      {bottomSheetContent && (
-        <BottomSheet closeEvent={() => setBottomSheetContent(null)}>
-          {content[bottomSheetContent]}
-        </BottomSheet>
-      )}
+      {bottomSheetComponent}
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,18 +3,19 @@
 import { ReactNode, useEffect, useState } from 'react';
 import { worker } from '../mocks/worker';
 
+import NotionList from '@components/item/NotionList';
 import Title from '@components/common/Title';
 import CircleLine from '@components/common/CircleLine';
-import NotionList from '@components/item/NotionList';
 import BottomSheet from '@components/common/BottomSheet';
 import NotionForm from '@components/item/NotionForm';
 
-type Content = 'notionItemForm' | 'notionItemPlusMenu' | 'notionItem';
+import { useRouter } from 'next/navigation';
+
+type Content = 'notionItemForm' | 'notionItemPlusMenu';
 
 const content: Record<Content, ReactNode> = {
   notionItemForm: <NotionForm />,
   notionItemPlusMenu: <></>,
-  notionItem: <></>,
 };
 
 export default function Home() {
@@ -32,9 +33,14 @@ export default function Home() {
   //   })();
   // }, []);
 
+  const router = useRouter();
   const [bottomSheetContent, setBottomSheetContent] = useState<Content | null>(
     null,
   );
+
+  const moveNotionItemPage = (id: number) => {
+    router.push(`/notion/${id}`, { scroll: true });
+  };
 
   return (
     <main className="flex flex-col gap-5">
@@ -45,7 +51,7 @@ export default function Home() {
         handleMoreMenuButtonClick={() =>
           setBottomSheetContent('notionItemPlusMenu')
         }
-        handleNotionItemClick={() => setBottomSheetContent('notionItem')}
+        handleNotionItemClick={moveNotionItemPage}
       />
       {bottomSheetContent && (
         <BottomSheet closeEvent={() => setBottomSheetContent(null)}>

--- a/components/common/Description/index.tsx
+++ b/components/common/Description/index.tsx
@@ -1,3 +1,3 @@
 export default function Description({ content }: { content: string }) {
-  return <p className="text-2xl">{content}</p>;
+  return <p className="text-lg">{content}</p>;
 }

--- a/components/context/RecentlyNotionContext.tsx
+++ b/components/context/RecentlyNotionContext.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState } from 'react';
+import { essenceNotion } from 'types/notion';
+
+interface RecentlyNotionContextProps {
+  recentlyNotionList: essenceNotion[];
+  addNotionItem: (notion: essenceNotion) => void;
+}
+
+export const recentlyNotionContext = createContext<RecentlyNotionContextProps>({
+  recentlyNotionList: [],
+  addNotionItem: (notion: essenceNotion) => {},
+});
+
+export default function RecentlyNotionContext({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [recentlyNotionList, setRecentlyNotionList] = useState<essenceNotion[]>(
+    [],
+  );
+
+  const addNotionItem = (notion: essenceNotion) => {
+    const notOverlapList = recentlyNotionList.filter(
+      ({ id }) => id !== notion.id,
+    );
+
+    const newList =
+      notOverlapList.length > 4
+        ? notOverlapList.slice(notOverlapList.length - 4)
+        : notOverlapList;
+
+    setRecentlyNotionList([...newList, notion]);
+  };
+
+  return (
+    <recentlyNotionContext.Provider
+      value={{ recentlyNotionList, addNotionItem }}
+    >
+      {children}
+    </recentlyNotionContext.Provider>
+  );
+}
+
+export const useRecentlyNotionContext = () => useContext(recentlyNotionContext);

--- a/components/item/Navigation/index.tsx
+++ b/components/item/Navigation/index.tsx
@@ -1,0 +1,36 @@
+import { Fragment } from 'react';
+
+import { useRecentlyNotionContext } from '@components/context/RecentlyNotionContext';
+
+import RoundSquare from '@components/common/RoundSquare';
+import { useRouter } from 'next/navigation';
+
+export default function Navigation() {
+  const router = useRouter();
+  const { recentlyNotionList } = useRecentlyNotionContext();
+
+  const moveNotionItemPage = (id: number) => {
+    router.push(`/notion/${id}`, { scroll: true });
+  };
+
+  return (
+    <div className="overflow-x-auto overflow-y-hidden snap-x">
+      <nav className="h-[60px] sm:h-[80px] flex gap-3 w-max">
+        {recentlyNotionList.map(({ id, name }) => {
+          return (
+            <Fragment key={id}>
+              <RoundSquare size="free">
+                <button
+                  className="w-max min-w-[80px] h-[30px] pl-2 pr-2"
+                  onClick={() => moveNotionItemPage(id)}
+                >
+                  {name}
+                </button>
+              </RoundSquare>
+            </Fragment>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/components/item/NotionForm/index.tsx
+++ b/components/item/NotionForm/index.tsx
@@ -13,7 +13,7 @@ export default function NotionForm() {
       <RoundSquare size="free">
         <textarea
           placeholder="개념 설명을 입력해주세요"
-          className="bg-transparent w-full resize-none h-[220px] p-3  focus:outline-none"
+          className="bg-transparent w-full resize-none h-[calc(35vh-110px)] p-3  focus:outline-none"
         />
       </RoundSquare>
       <RoundSquare>

--- a/components/item/NotionList/NotionList.stories.tsx
+++ b/components/item/NotionList/NotionList.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
+import { mockNotionBanana } from '@mocks/mockData/notionList';
+
 import NotionList from '.';
 
 /**
@@ -22,6 +24,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
+    notionList: mockNotionBanana.relatedNotionList,
     handlePlusButtonClick: action('더하기 버튼 클릭 이벤트 발생'),
     handleMoreMenuButtonClick: action('노션 내 더보기 버튼 클릭 이벤트 발생'),
     handleNotionItemClick: action('노션 아이템 버튼 클릭 이벤트 발생'),

--- a/components/item/NotionList/index.tsx
+++ b/components/item/NotionList/index.tsx
@@ -6,7 +6,7 @@ import PlusNotionButton from '../PlusNotionButton';
 interface NotionListProps {
   handlePlusButtonClick: () => void;
   handleMoreMenuButtonClick: () => void;
-  handleNotionItemClick: () => void;
+  handleNotionItemClick: (id: number) => void;
 }
 
 export default function NotionList({
@@ -22,7 +22,7 @@ export default function NotionList({
             <NotionItem
               content={item.name}
               handleMoreMenuButtonClick={handleMoreMenuButtonClick}
-              handleNotionItemClick={handleNotionItemClick}
+              handleNotionItemClick={() => handleNotionItemClick(item.id)}
             />
           </li>
         );

--- a/components/item/NotionList/index.tsx
+++ b/components/item/NotionList/index.tsx
@@ -1,15 +1,17 @@
-import { notionList } from '@mocks/mockData/notionList';
-
 import NotionItem from '../NotionItem';
 import PlusNotionButton from '../PlusNotionButton';
 
+import { essenceNotion } from 'types/notion';
+
 interface NotionListProps {
+  notionList: essenceNotion[];
   handlePlusButtonClick: () => void;
   handleMoreMenuButtonClick: () => void;
   handleNotionItemClick: (id: number) => void;
 }
 
 export default function NotionList({
+  notionList,
   handlePlusButtonClick,
   handleMoreMenuButtonClick,
   handleNotionItemClick,

--- a/hooks/useBottomSheetContent.tsx
+++ b/hooks/useBottomSheetContent.tsx
@@ -1,0 +1,30 @@
+import { ReactNode, useState } from 'react';
+
+import NotionForm from '@components/item/NotionForm';
+import BottomSheet from '@components/common/BottomSheet';
+
+type Content = 'notionItemForm' | 'notionItemPlusMenu';
+
+const content: Record<Content, ReactNode> = {
+  notionItemForm: <NotionForm />,
+  notionItemPlusMenu: <></>,
+};
+
+export const useBottomSheetContent = () => {
+  const [bottomSheetContent, setBottomSheetContent] = useState<Content | null>(
+    null,
+  );
+
+  return {
+    handlePlusButtonClick: () => setBottomSheetContent('notionItemForm'),
+    handleMoreMenuButtonClick: () =>
+      setBottomSheetContent('notionItemPlusMenu'),
+    bottomSheetComponent: bottomSheetContent ? (
+      <BottomSheet closeEvent={() => setBottomSheetContent(null)}>
+        {content[bottomSheetContent]}
+      </BottomSheet>
+    ) : (
+      <></>
+    ),
+  };
+};

--- a/hooks/useMovePage.ts
+++ b/hooks/useMovePage.ts
@@ -1,0 +1,12 @@
+import { useRouter } from 'next/navigation';
+
+export const useMovePage = () => {
+  const router = useRouter();
+
+  const moveNotionItemPage = (id: number, callback?: () => void) => {
+    callback && callback();
+    router.push(`/notion/${id}`, { scroll: true });
+  };
+
+  return { moveNotionItemPage };
+};

--- a/mocks/mockData/notionList.ts
+++ b/mocks/mockData/notionList.ts
@@ -1,4 +1,6 @@
-export const notionBanana = {
+import { Notion } from 'types/notion';
+
+export const mockNotionBanana: Notion = {
   id: 0,
   name: '바나나',
   description: '노랗고 달달한 더운 지역에서 재배되는 과일',
@@ -18,7 +20,7 @@ export const notionBanana = {
   ],
 };
 
-export const notionApple = {
+export const mockNotionApple: Notion = {
   id: 5,
   name: '사과',
   description: '빨갛고 동그란, 나무에 열리는 과실',
@@ -34,7 +36,7 @@ export const notionApple = {
   ],
 };
 
-export const notionBear = {
+export const mockNotionBear: Notion = {
   id: 9,
   name: '곰',
   description: '겨울잠을 자는 크고 힘이 쎈 동물',
@@ -46,4 +48,8 @@ export const notionBear = {
   ],
 };
 
-export const notionList = [notionBear, notionApple, notionBanana];
+export const mockNotionList: Notion[] = [
+  mockNotionBear,
+  mockNotionApple,
+  mockNotionBanana,
+];

--- a/mocks/mockData/notionList.ts
+++ b/mocks/mockData/notionList.ts
@@ -1,30 +1,5 @@
-export const notionBear = {
-  name: '곰',
-  description: '겨울잠을 자는 크고 힘이 쎈 동물',
-  relatedNotionList: [
-    {
-      id: 8,
-      name: '연어',
-    },
-  ],
-};
-
-export const notionApple = {
-  name: '사과',
-  description: '빨갛고 동그란, 나무에 열리는 과실',
-  relatedNotionList: [
-    {
-      id: 3,
-      name: '백설공주',
-    },
-    {
-      id: 4,
-      name: '바나나',
-    },
-  ],
-};
-
 export const notionBanana = {
+  id: 0,
   name: '바나나',
   description: '노랗고 달달한 더운 지역에서 재배되는 과일',
   relatedNotionList: [
@@ -39,6 +14,34 @@ export const notionBanana = {
     {
       id: 5,
       name: '사과',
+    },
+  ],
+};
+
+export const notionApple = {
+  id: 5,
+  name: '사과',
+  description: '빨갛고 동그란, 나무에 열리는 과실',
+  relatedNotionList: [
+    {
+      id: 3,
+      name: '백설공주',
+    },
+    {
+      id: 4,
+      name: '바나나',
+    },
+  ],
+};
+
+export const notionBear = {
+  id: 9,
+  name: '곰',
+  description: '겨울잠을 자는 크고 힘이 쎈 동물',
+  relatedNotionList: [
+    {
+      id: 8,
+      name: '연어',
     },
   ],
 };

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -1,0 +1,11 @@
+export interface essenceNotion {
+  id: number;
+  name: string;
+}
+
+export interface Notion {
+  id: number;
+  name: string;
+  description: string;
+  relatedNotionList: essenceNotion[];
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #6

<br/>

## 📝 작업 요약
- 개념 상세 페이지 제작한다
    - 추가 버튼을 누르면 폼이 포함된 바텀시트가 나온다
- 개념 아이템을 누르면 상세페이지로 이동한다.
- 상단에는 최근 방문한 개념 이름이 렌더링된다.


<br/>

## ⏰ 소요 시간
1일

<br/>

## 🔎 작업 상세 설명
- 개념 상세 페이지 제작한다
    - 개념 이름과 설명, 관련 개념 목록, 더하기 버튼이 있다
    - 추가 버튼을 누르면 폼이 포함된 바텀시트가 나온다
        - 목록과 동일한 추가 폼
- 개념 아이템을 누르면 상세페이지로 이동한다.
    - useNavigation을 사용 = 훅으로 분리
- 상단에는 최근 방문한 개념 이름이 렌더링된다.
    - 전체 레이아웃에 contextApi 설치
    - 네비게이션에 최근 방문한 개념 나열
    - 상세페이지로 진입해서 다른 개념을 누른 경우에 최근 개념에 추가된다.
 

<br/>

## 🌟 참고 사항
- [next.js 에서 contextAPI 사용하기](https://www.js-craft.io/blog/using-react-context-nextjs-13/)


<br/>
