### PR TITLE
Feat/#18_애니메이션, 스켈레톤 추가, 방문노션 로직 수정

### DIFF
--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -18,7 +18,7 @@ import { Notion } from 'types/notion';
 export default function notion({ params }: { params: { id: number } }) {
   const [data, setData] = useState<Notion>();
 
-  const { addNotionItem } = useRecentlyNotionContext();
+  const { updateRecentlyNotionList } = useRecentlyNotionContext();
   const { moveNotionItemPage } = useMovePage();
 
   //현재는 수정기능이 없으므로 "make"로 설정
@@ -38,7 +38,11 @@ export default function notion({ params }: { params: { id: number } }) {
     (async () => {
       const data = await getFetch<Notion>(url);
       setData(data);
-      addNotionItem({ id: params.id, name: data.name });
+      updateRecentlyNotionList(
+        { id: data.id, name: data.name },
+        data.id,
+        data.relatedNotions,
+      );
     })();
   }, []);
 

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -44,10 +44,12 @@ export default function notion({ params }: { params: { id: number } }) {
 
   return (
     data && (
-      <main className="flex flex-col gap-5">
-        <Title content={data.name} />
-        <CircleLine amount={8} />
-        <Description content={data.content} />
+      <main className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <div className="flex flex-col gap-5">
+          <Title content={data.name} />
+          <CircleLine amount={8} />
+          <Description content={data.content} />
+        </div>
         <NotionList
           notionList={data.relatedNotions}
           handlePlusButtonClick={handlePlusButtonClick}

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -31,7 +31,6 @@ export default function notion({ params }: { params: { id: number } }) {
   const url = GET_URL.NOTION_ITEM(params.id);
 
   const handleNotionItemClick = (id: number) => {
-    data && addNotionItem({ id: params.id, name: data.name });
     moveNotionItemPage(id);
   };
 
@@ -39,6 +38,7 @@ export default function notion({ params }: { params: { id: number } }) {
     (async () => {
       const data = await getFetch<Notion>(url);
       setData(data);
+      addNotionItem({ id: params.id, name: data.name });
     })();
   }, []);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ export default function Home() {
       <Title content="개념" />
       <CircleLine amount={8} />
       <NotionList
+        style="md:grid-cols-2 lg:grid-cols-3"
         notionList={[
           ...mockNotionBear.relatedNotions,
           ...mockNotionBanana.relatedNotions,

--- a/components/common/BottomSheet/index.tsx
+++ b/components/common/BottomSheet/index.tsx
@@ -1,5 +1,7 @@
+'use client';
+
 import { useKeyEscClose } from 'hooks/useKeyEscClose';
-import { MouseEventHandler, ReactNode } from 'react';
+import { MouseEventHandler, ReactNode, useEffect, useState } from 'react';
 import { Size } from 'types/style';
 
 interface BottomSheetProps {
@@ -14,12 +16,21 @@ const heightStyle: Record<Size, string> = {
   lg: 'min-h-[60%]',
 };
 
+const animation = {
+  open: 'animate-[bottomUp_0.35s_ease-in-out_forwards]',
+  close: 'animate-[bottomDown_0.35s_ease-in-out_forwards]',
+  fadeIn: 'animate-[fadeIn_0.35s_ease-in-out_forwards]',
+  fadeOut: 'animate-[fadeOut_0.35s_ease-in-out_forwards]',
+};
+
 export default function BottomSheet({
   children,
   size = 'md',
   closeEvent,
 }: BottomSheetProps) {
+  const [isOpen, setIsOpen] = useState(true);
   const closeModalKeyboardEvent = useKeyEscClose(closeEvent);
+  let timeId = 0;
 
   const closeModalClickEvent: MouseEventHandler<
     HTMLDivElement | HTMLButtonElement
@@ -29,14 +40,25 @@ export default function BottomSheet({
     if (
       target.id === 'bottom-sheet-backdrop' ||
       target.id === 'bottom-sheet-close-button'
-    )
-      closeEvent();
+    ) {
+      setIsOpen(false);
+
+      timeId = window.setTimeout(() => {
+        closeEvent();
+      }, 350);
+    }
   };
+
+  useEffect(() => {
+    return () => clearTimeout(timeId);
+  }, []);
 
   return (
     <div
       id="bottom-sheet-backdrop"
-      className="fixed inset-0 bg-black/30 z-10 flex justify-center items-end"
+      className={`fixed inset-0 bg-black/30 z-10 flex justify-center items-end ${
+        isOpen ? animation.fadeIn : animation.fadeOut
+      }`}
       onClick={closeModalClickEvent}
       onKeyUp={() => closeModalKeyboardEvent}
       aria-label="모달"
@@ -49,7 +71,11 @@ export default function BottomSheet({
       <div
         role="region"
         aria-label="모달 내 컨텐츠"
-        className={`bg-white z-20 flex justify-center items-center flex-col ${heightStyle[size]} w-full max-w-[1000px] rounded-t-lg`}
+        className={`bg-white z-20 flex justify-center items-center flex-col ${
+          heightStyle[size]
+        } w-full max-w-[1000px] rounded-t-lg ${
+          isOpen ? animation.open : animation.close
+        }`}
       >
         {children}
       </div>

--- a/components/common/Description/index.tsx
+++ b/components/common/Description/index.tsx
@@ -1,3 +1,22 @@
+'use client';
+
+import { useState } from 'react';
+
 export default function Description({ content }: { content: string }) {
-  return content.split('\n').map((text, index) => <p key={index}>{text}</p>);
+  const [isNowBlur, setIsNowBlur] = useState(true);
+
+  const toggleBlur = () => {
+    setIsNowBlur(!isNowBlur);
+  };
+
+  return (
+    <div
+      className={`${isNowBlur ? 'blur-sm' : ''} cursor-pointer`}
+      onClick={toggleBlur}
+    >
+      {content.split('\n').map((text, index) => (
+        <p key={index}>{text}</p>
+      ))}
+    </div>
+  );
 }

--- a/components/common/RoundSquare/index.tsx
+++ b/components/common/RoundSquare/index.tsx
@@ -17,6 +17,8 @@ const heightStyle: Record<Size | 'free', string> = {
 const colorInfo: Record<Color, string> = {
   default: 'bg-slate-100 hover:bg-slate-200',
   blue: 'bg-blue-300 hover:bg-blue-400',
+  orange: 'bg-orange-300 hover:bg-orange-400',
+  lightOrange: 'bg-orange-100 hover:bg-orange-200',
 };
 
 export default function RoundSquare({

--- a/components/context/RecentlyNotionContext.tsx
+++ b/components/context/RecentlyNotionContext.tsx
@@ -1,17 +1,29 @@
 import { createContext, useContext, useState } from 'react';
 import { EssenceNotion } from 'types/notion';
+import { Color } from 'types/style';
 
-interface ContextNotionInfo extends EssenceNotion {}
+interface ContextNotionInfo extends EssenceNotion {
+  color: Color;
+}
+
 interface RecentlyNotionContextProps {
-  recentlyNotionList: EssenceNotion[];
-  addNotionItem: (notion: EssenceNotion) => void;
+  recentlyNotionList: ContextNotionInfo[];
+  updateRecentlyNotionList: (
+    notionForAdd: EssenceNotion,
+    nowNotionId: number,
+    relationNotionList: EssenceNotion[],
+  ) => void;
 }
 
 const limitCount = 7;
 
 export const recentlyNotionContext = createContext<RecentlyNotionContextProps>({
   recentlyNotionList: [],
-  addNotionItem: (notion: EssenceNotion) => {},
+  updateRecentlyNotionList: (
+    notionForAdd: EssenceNotion,
+    nowNotionId: number,
+    relationNotionList: EssenceNotion[],
+  ) => {},
 });
 
 export default function RecentlyNotionContext({
@@ -19,31 +31,58 @@ export default function RecentlyNotionContext({
 }: {
   children: React.ReactNode;
 }) {
-  const [recentlyNotionList, setRecentlyNotionList] = useState<EssenceNotion[]>(
-    [],
-  );
+  const [recentlyNotionList, setRecentlyNotionList] = useState<
+    ContextNotionInfo[]
+  >([]);
 
-  const addNotionItem = (notion: EssenceNotion) => {
-    const notOverlapList = recentlyNotionList.filter(
-      ({ id }) => id !== notion.id,
-    );
+  const addNotionItem = (
+    notion: EssenceNotion,
+    notionList: ContextNotionInfo[],
+  ): ContextNotionInfo[] => {
+    const notOverlapList = notionList.filter(({ id }) => id !== notion.id);
 
     const newList =
       notOverlapList.length > limitCount
         ? notOverlapList.slice(notOverlapList.length - limitCount)
         : notOverlapList;
 
-    setRecentlyNotionList([...newList, notion]);
+    return [...newList, { ...notion, color: 'default' }];
   };
 
   const checkNotionRelation = (
+    notionList: ContextNotionInfo[],
     nowNotionId: number,
     relationNotionList: EssenceNotion[],
-  ) => {};
+  ): ContextNotionInfo[] => {
+    const relationNotionIdList = relationNotionList.map((notion) => notion.id);
+
+    return notionList.map((notion) => {
+      if (notion.id === nowNotionId) return { ...notion, color: 'orange' };
+
+      if (relationNotionIdList.includes(notion.id))
+        return { ...notion, color: 'lightOrange' };
+
+      return { ...notion, color: 'default' };
+    });
+  };
+
+  const updateRecentlyNotionList = (
+    notionForAdd: EssenceNotion,
+    nowNotionId: number,
+    relationNotionList: EssenceNotion[],
+  ) => {
+    setRecentlyNotionList(
+      checkNotionRelation(
+        addNotionItem(notionForAdd, recentlyNotionList),
+        nowNotionId,
+        relationNotionList,
+      ),
+    );
+  };
 
   return (
     <recentlyNotionContext.Provider
-      value={{ recentlyNotionList, addNotionItem }}
+      value={{ recentlyNotionList, updateRecentlyNotionList }}
     >
       {children}
     </recentlyNotionContext.Provider>

--- a/components/context/RecentlyNotionContext.tsx
+++ b/components/context/RecentlyNotionContext.tsx
@@ -6,6 +6,8 @@ interface RecentlyNotionContextProps {
   addNotionItem: (notion: essenceNotion) => void;
 }
 
+const limitCount = 7;
+
 export const recentlyNotionContext = createContext<RecentlyNotionContextProps>({
   recentlyNotionList: [],
   addNotionItem: (notion: essenceNotion) => {},
@@ -26,8 +28,8 @@ export default function RecentlyNotionContext({
     );
 
     const newList =
-      notOverlapList.length > 4
-        ? notOverlapList.slice(notOverlapList.length - 4)
+      notOverlapList.length > limitCount
+        ? notOverlapList.slice(notOverlapList.length - limitCount)
         : notOverlapList;
 
     setRecentlyNotionList([...newList, notion]);

--- a/components/context/RecentlyNotionContext.tsx
+++ b/components/context/RecentlyNotionContext.tsx
@@ -1,16 +1,17 @@
 import { createContext, useContext, useState } from 'react';
-import { essenceNotion } from 'types/notion';
+import { EssenceNotion } from 'types/notion';
 
+interface ContextNotionInfo extends EssenceNotion {}
 interface RecentlyNotionContextProps {
-  recentlyNotionList: essenceNotion[];
-  addNotionItem: (notion: essenceNotion) => void;
+  recentlyNotionList: EssenceNotion[];
+  addNotionItem: (notion: EssenceNotion) => void;
 }
 
 const limitCount = 7;
 
 export const recentlyNotionContext = createContext<RecentlyNotionContextProps>({
   recentlyNotionList: [],
-  addNotionItem: (notion: essenceNotion) => {},
+  addNotionItem: (notion: EssenceNotion) => {},
 });
 
 export default function RecentlyNotionContext({
@@ -18,11 +19,11 @@ export default function RecentlyNotionContext({
 }: {
   children: React.ReactNode;
 }) {
-  const [recentlyNotionList, setRecentlyNotionList] = useState<essenceNotion[]>(
+  const [recentlyNotionList, setRecentlyNotionList] = useState<EssenceNotion[]>(
     [],
   );
 
-  const addNotionItem = (notion: essenceNotion) => {
+  const addNotionItem = (notion: EssenceNotion) => {
     const notOverlapList = recentlyNotionList.filter(
       ({ id }) => id !== notion.id,
     );
@@ -34,6 +35,11 @@ export default function RecentlyNotionContext({
 
     setRecentlyNotionList([...newList, notion]);
   };
+
+  const checkNotionRelation = (
+    nowNotionId: number,
+    relationNotionList: EssenceNotion[],
+  ) => {};
 
   return (
     <recentlyNotionContext.Provider

--- a/components/item/Navigation/index.tsx
+++ b/components/item/Navigation/index.tsx
@@ -21,10 +21,10 @@ export default function Navigation() {
             홈페이지
           </button>
         </RoundSquare>
-        {recentlyNotionList.map(({ id, name }) => {
+        {recentlyNotionList.map(({ id, name, color }) => {
           return (
             <Fragment key={id}>
-              <RoundSquare size="free">
+              <RoundSquare size="free" color={color}>
                 <button
                   className="w-max min-w-[80px] h-[30px] pl-2 pr-2"
                   onClick={() => moveNotionItemPage(id)}

--- a/components/item/NotionList/index.tsx
+++ b/components/item/NotionList/index.tsx
@@ -4,6 +4,7 @@ import PlusNotionButton from '../PlusNotionButton';
 import { essenceNotion } from 'types/notion';
 
 interface NotionListProps {
+  style?: string;
   notionList: essenceNotion[];
   handlePlusButtonClick: () => void;
   handleMoreMenuButtonClick: () => void;
@@ -11,13 +12,14 @@ interface NotionListProps {
 }
 
 export default function NotionList({
+  style = '',
   notionList,
   handlePlusButtonClick,
   handleMoreMenuButtonClick,
   handleNotionItemClick,
 }: NotionListProps) {
   return (
-    <ul className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+    <ul className={`h-fit grid grid-cols-1 gap-3 items-start ${style}`}>
       {notionList.map((item) => {
         return (
           <li key={item.name}>

--- a/components/item/NotionList/index.tsx
+++ b/components/item/NotionList/index.tsx
@@ -1,11 +1,11 @@
 import NotionItem from '../NotionItem';
 import PlusNotionButton from '../PlusNotionButton';
 
-import { essenceNotion } from 'types/notion';
+import { EssenceNotion } from 'types/notion';
 
 interface NotionListProps {
   style?: string;
-  notionList: essenceNotion[];
+  notionList: EssenceNotion[];
   handlePlusButtonClick: () => void;
   handleMoreMenuButtonClick: () => void;
   handleNotionItemClick: (id: number) => void;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,30 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      keyframes: {
+        bottomUp: {
+          '100%': { transform: 'none' },
+          '0%': { transform: 'translateY(100%)' },
+        },
+        bottomDown: {
+          '0%': { transform: 'none' },
+          '100%': { transform: 'translateY(100%)' },
+        },
+        fadeIn: {
+          '0%': { opacity: '0' },
+          '100%': { opacity: '1' },
+        },
+        fadeOut: {
+          '0%': { opacity: '1' },
+          '100%': { opacity: '0' },
+        },
+      },
+      animation: {
+        bottomUp: 'bottomUp 0.35s ease-in-out forwards',
+        bottomDown: 'bottomDown 0.35s ease-in-out forwards',
+        fadeIn: 'fadeIn 0.35s ease-in-out forwards',
+        fadeOut: 'fadeOut 0.35s ease-in-out forwards',
+      },
     },
   },
   plugins: [],

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -1,4 +1,4 @@
-export interface essenceNotion {
+export interface EssenceNotion {
   id: number;
   name: string;
 }
@@ -7,7 +7,7 @@ export interface Notion {
   id: number;
   name: string;
   content: string;
-  relatedNotions: essenceNotion[];
+  relatedNotions: EssenceNotion[];
 }
 
 export interface RequestNotion {

--- a/types/style.ts
+++ b/types/style.ts
@@ -1,2 +1,2 @@
 export type Size = 'sm' | 'md' | 'lg';
-export type Color = 'default' | 'blue';
+export type Color = 'default' | 'blue' | 'orange' | 'lightOrange';


### PR DESCRIPTION
## 🔥 연관 이슈

close: #18

<br/>

## 📝 작업 요약
- [x] 바텀시트 등장 및 제거 애니메이션 추가
    - [x] 등장: 하단에서 올라오기
    - [x] 제거: 하든으로 내려가기
- [x] 내용 기본이 안보이고 클릭해야 등장하는 기능 추가
    - [x] 클릭 전엔 불투명하게 보이게 설정
- [x] 상단 방문 노션 현재 노션도 포함되게 로직 수정
    - [x] 관련 노션은 색도 다르게 설정  

<br/>

## ⏰ 소요 시간
2h

<br/>

## 🔎 작업 상세 설명
- 바텀시트 등장 및 제거 애니메이션 추가
    - 커스텀한 애니메이션 추가해서 배경은 fadeIn/Out, 시트는 오르락, 내리락 하게 설정
- 내용 기본이 안보이고 클릭해야 등장하는 기능 추가
    - 설명 컴포넌트 자체에 이벤트 설정. 이벤트 안하는 설명 컴포넌트가 필요하다면 그때 다시 만들면 될 것 같음
- 상단 방문 노션 현재 노션도 포함되게 로직 수정
    - 상세페이지 들어가 데이터가 불러와지면 네비가 변화하도록 설정
    - 컨텍스트를 수정하여 네비게이션 색 데이터를 가지고 있도록 설정
    - 색을 가지게 하는 것이 좋다고 느껴지지는 않으나 관계 명명을 어떻게 하는게 좋을지 모르겠어서 일단 color로 설정  

<br/>

