### PR TITLE
Feat/#21_노션 그래프 관련 api 연결 (노션 그래프 목록 조회/ 노션 그래프 내 모든 노션목록 조회)

### DIFF
--- a/app/graph/[id]/page.tsx
+++ b/app/graph/[id]/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import CircleLine from '@components/common/CircleLine';
+import Title from '@components/common/Title';
+import NotionList from '@components/item/NotionList';
+
+import { useMovePage } from 'hooks/useMovePage';
+
+import { GET_URL } from 'constants/url';
+import { getFetch } from 'utils/fetch';
+import { EssenceNotion } from 'types/notion';
+
+export default function notion({ params }: { params: { id: number } }) {
+  const [data, setData] = useState<EssenceNotion[]>();
+
+  const { moveNotionItemPage } = useMovePage();
+
+  const url = GET_URL.NOTION_GRAPH_ITEM_LIST(params.id);
+
+  const handleNotionItemClick = (id: number) => {
+    moveNotionItemPage(id);
+  };
+
+  useEffect(() => {
+    (async () => {
+      const data = await getFetch<EssenceNotion[]>(url);
+      setData(data);
+    })();
+  }, []);
+
+  return (
+    data && (
+      <main className="flex flex-col gap-5">
+        <Title content={data && data[0] ? data[0].name : 'Graph loading...'} />
+        <CircleLine amount={8} />
+        <NotionList
+          style="md:grid-cols-2 lg:grid-cols-3"
+          notionList={data}
+          handleNotionItemClick={handleNotionItemClick}
+        />
+      </main>
+    )
+  );
+}

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -17,6 +17,7 @@ import { Notion } from 'types/notion';
 
 export default function notion({ params }: { params: { id: number } }) {
   const [data, setData] = useState<Notion>();
+  const [trigger, setTrigger] = useState(false);
 
   const { updateRecentlyNotionList } = useRecentlyNotionContext();
   const { moveNotionItemPage } = useMovePage();
@@ -26,7 +27,11 @@ export default function notion({ params }: { params: { id: number } }) {
     handlePlusButtonClick,
     handleMoreMenuButtonClick,
     bottomSheetComponent,
-  } = useNotionItemBottomSheet('make', data);
+  } = useNotionItemBottomSheet({
+    type: 'make',
+    notion: data,
+    sideEffectFn: () => setTrigger(!trigger),
+  });
 
   const url = GET_URL.NOTION_ITEM(params.id);
 
@@ -44,7 +49,7 @@ export default function notion({ params }: { params: { id: number } }) {
         data.relatedNotions,
       );
     })();
-  }, []);
+  }, [trigger]);
 
   return (
     data && (

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -52,7 +52,9 @@ export default function notion({ params }: { params: { id: number } }) {
         <div className="flex flex-col gap-5">
           <Title content={data.name} />
           <CircleLine amount={8} />
-          <Description content={data.content} />
+          <div className="min-h-[150px]">
+            <Description content={data.content} />
+          </div>
         </div>
         <NotionList
           notionList={data.relatedNotions}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
     sideEffectFn: () => setTrigger(!trigger),
   });
 
-  const { moveNotionItemPage } = useMovePage();
+  const { moveNotionGraphItemListPage } = useMovePage();
 
   useEffect(() => {
     (async () => {
@@ -45,7 +45,7 @@ export default function Home() {
           notionList={data}
           handlePlusButtonClick={handlePlusButtonClick}
           handleMoreMenuButtonClick={handleMoreMenuButtonClick}
-          handleNotionItemClick={moveNotionItemPage}
+          handleNotionItemClick={moveNotionGraphItemListPage}
         />
         {bottomSheetComponent}
       </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,21 @@
 'use client';
 
+import { useEffect, useState } from 'react';
+
 import NotionList from '@components/item/NotionList';
 import Title from '@components/common/Title';
 import CircleLine from '@components/common/CircleLine';
 
-import { mockNotionBear, mockNotionSnowWhite } from '@mocks/mockData/notion';
 import { useNotionItemBottomSheet } from 'hooks/useNotionItemBottomSheet';
 import { useMovePage } from 'hooks/useMovePage';
 
+import { EssenceNotion } from 'types/notion';
+import { getFetch } from 'utils/fetch';
+import { GET_URL } from 'constants/url';
+
 export default function Home() {
+  const [data, setData] = useState<EssenceNotion[]>();
+
   const {
     handlePlusButtonClick,
     handleMoreMenuButtonClick,
@@ -17,21 +24,27 @@ export default function Home() {
 
   const { moveNotionItemPage } = useMovePage();
 
+  useEffect(() => {
+    (async () => {
+      const data = await getFetch<EssenceNotion[]>(GET_URL.NOTION_GRAPH_LIST());
+      setData(data);
+    })();
+  }, []);
+
   return (
-    <main className="flex flex-col gap-5">
-      <Title content="R:map" />
-      <CircleLine amount={8} />
-      <NotionList
-        style="md:grid-cols-2 lg:grid-cols-3"
-        notionList={[
-          ...mockNotionBear.relatedNotions,
-          ...mockNotionSnowWhite.relatedNotions,
-        ]}
-        handlePlusButtonClick={handlePlusButtonClick}
-        handleMoreMenuButtonClick={handleMoreMenuButtonClick}
-        handleNotionItemClick={moveNotionItemPage}
-      />
-      {bottomSheetComponent}
-    </main>
+    data && (
+      <main className="flex flex-col gap-5">
+        <Title content="R:map" />
+        <CircleLine amount={8} />
+        <NotionList
+          style="md:grid-cols-2 lg:grid-cols-3"
+          notionList={data}
+          handlePlusButtonClick={handlePlusButtonClick}
+          handleMoreMenuButtonClick={handleMoreMenuButtonClick}
+          handleNotionItemClick={moveNotionItemPage}
+        />
+        {bottomSheetComponent}
+      </main>
+    )
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,12 +15,16 @@ import { GET_URL } from 'constants/url';
 
 export default function Home() {
   const [data, setData] = useState<EssenceNotion[]>();
+  const [trigger, setTrigger] = useState(false);
 
   const {
     handlePlusButtonClick,
     handleMoreMenuButtonClick,
     bottomSheetComponent,
-  } = useNotionItemBottomSheet('make');
+  } = useNotionItemBottomSheet({
+    type: 'make',
+    sideEffectFn: () => setTrigger(!trigger),
+  });
 
   const { moveNotionItemPage } = useMovePage();
 
@@ -29,7 +33,7 @@ export default function Home() {
       const data = await getFetch<EssenceNotion[]>(GET_URL.NOTION_GRAPH_LIST());
       setData(data);
     })();
-  }, []);
+  }, [trigger]);
 
   return (
     data && (

--- a/components/item/NotionItem/index.tsx
+++ b/components/item/NotionItem/index.tsx
@@ -7,7 +7,7 @@ import RoundSquare from '../../common/RoundSquare';
 interface NotionItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   content: string;
   handleNotionItemClick: () => void;
-  handleMoreMenuButtonClick: () => void;
+  handleMoreMenuButtonClick?: () => void;
 }
 
 export default function NotionItem({
@@ -19,7 +19,7 @@ export default function NotionItem({
     HTMLButtonElement
   > = (event) => {
     event.stopPropagation();
-    handleMoreMenuButtonClick();
+    handleMoreMenuButtonClick && handleMoreMenuButtonClick();
   };
 
   return (
@@ -30,10 +30,12 @@ export default function NotionItem({
       >
         <CircleLine amount={1} />
         <button className="w-full truncate text-left">{content}</button>
-        <MoreMenuButton
-          size="sm"
-          onClick={handleMoreNotionButtonClickWithoutBubbling}
-        />
+        {handleMoreMenuButtonClick && (
+          <MoreMenuButton
+            size="sm"
+            onClick={handleMoreNotionButtonClickWithoutBubbling}
+          />
+        )}
       </div>
     </RoundSquare>
   );

--- a/components/item/NotionList/index.tsx
+++ b/components/item/NotionList/index.tsx
@@ -6,8 +6,8 @@ import { EssenceNotion } from 'types/notion';
 interface NotionListProps {
   style?: string;
   notionList: EssenceNotion[];
-  handlePlusButtonClick: () => void;
-  handleMoreMenuButtonClick: () => void;
+  handlePlusButtonClick?: () => void;
+  handleMoreMenuButtonClick?: () => void;
   handleNotionItemClick: (id: number) => void;
 }
 
@@ -31,9 +31,11 @@ export default function NotionList({
           </li>
         );
       })}
-      <li>
-        <PlusNotionButton onClick={handlePlusButtonClick} />
-      </li>
+      {handlePlusButtonClick && (
+        <li>
+          <PlusNotionButton onClick={handlePlusButtonClick} />
+        </li>
+      )}
     </ul>
   );
 }

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -4,6 +4,8 @@ const base = process.env.NEXT_PUBLIC_BASE_URL;
 export const GET_URL = {
   NOTION_ITEM_MOCK: () => `/notions/:id`,
   NOTION_ITEM: (id: number) => `${base}/notions/${id}`,
+  NOTION_GRAPH_LIST: () => `${base}/graphs`,
+  NOTION_GRAPH_ITEM_LIST: (id: number) => `${base}/graphs/${id}`,
 };
 
 export const POST_URL = {

--- a/hooks/useMovePage.ts
+++ b/hooks/useMovePage.ts
@@ -8,10 +8,15 @@ export const useMovePage = () => {
     router.push(`/`, { scroll: true });
   };
 
+  const moveNotionGraphItemListPage = (id: number, callback?: () => void) => {
+    callback && callback();
+    router.push(`/graph/${id}`, { scroll: true });
+  };
+
   const moveNotionItemPage = (id: number, callback?: () => void) => {
     callback && callback();
     router.push(`/notion/${id}`, { scroll: true });
   };
 
-  return { moveMainPage, moveNotionItemPage };
+  return { moveMainPage, moveNotionGraphItemListPage, moveNotionItemPage };
 };

--- a/hooks/useNotionItemBottomSheet.tsx
+++ b/hooks/useNotionItemBottomSheet.tsx
@@ -6,10 +6,15 @@ import { Notion } from 'types/notion';
 
 type Content = 'notionItemForm' | 'notionItemPlusMenu';
 
-export const useNotionItemBottomSheet = (
-  type: 'make' | 'edit',
-  notion?: Notion,
-) => {
+export const useNotionItemBottomSheet = ({
+  type,
+  notion,
+  sideEffectFn,
+}: {
+  type: 'make' | 'edit';
+  notion?: Notion;
+  sideEffectFn?: () => void;
+}) => {
   const [bottomSheetContent, setBottomSheetContent] = useState<Content | null>(
     null,
   );
@@ -18,13 +23,14 @@ export const useNotionItemBottomSheet = (
     setBottomSheetContent(null);
   };
 
+  const submitSideEffect = () => {
+    sideEffectFn && sideEffectFn();
+    setBottomSheetContent(null);
+  };
+
   const content: Record<Content, ReactNode> = {
     notionItemForm: (
-      <NotionForm
-        type={type}
-        data={notion}
-        submitEvent={resetBottomSheetContent}
-      />
+      <NotionForm type={type} data={notion} submitEvent={submitSideEffect} />
     ),
     notionItemPlusMenu: <></>,
   };


### PR DESCRIPTION
## 🔥 연관 이슈

close: #21

<br/>

## 📝 작업 요약
- 노션그래프 목록 조회
- 노션 그래프 내 노션 목록 조회
- fix: 노션 추가했을때 새로고침해야 보이는 문제점 해결

<br/>

## ⏰ 소요 시간
1시간

<br/>

## 🔎 작업 상세 설명
- 기존 노션 리스트 컴포넌트
    - 노션 더보기 메뉴버튼과 노션 추가 버튼이 필수로 포함
    - 해당 부분이 노션그래프 내 노션 리스트 페이지에서는 필요없었음
    - 이벤트를 옵셔널로 받아 있는 경우에만 해당 트리거 컴포넌트가 렌더링되도록 수정
- 라우팅 흐름 변화
    - 메인페이지(노션 그래프 목록) > 노션 그래프 내 노션 목록 > 노션 상세 페이지
- 노션 추가하는 경우 refetch


<br/>

## 🌟 참고 사항
- 노션 그래프 내 노션 목록 페이지 제목은 노션 목록 첫번째 요소의 이름이 렌더링됨

<br/>
