### PR TITLE
api 수정: 노션 get api에 소속폴더 id 추가, 폴더 내 노션 리스트 get api를 폴더 정보 get api로 수정_Feat/#27

### DIFF
--- a/app/folder/[id]/page.tsx
+++ b/app/folder/[id]/page.tsx
@@ -21,7 +21,7 @@ import { deleteNotion } from 'utils/deleteNotion';
 import ButtonWithCircle from '@components/common/ButtonWithCircle';
 
 export default function Page({ params }: { params: { id: number } }) {
-  const [data, setData] = useState<EssentialNotion[]>();
+  const [data, setData] = useState<NotionFolder>();
   const [trigger, setTrigger] = useState(0);
 
   const { moveNotionItemPage } = useMovePage();
@@ -36,10 +36,25 @@ export default function Page({ params }: { params: { id: number } }) {
     open: openSubmitButtonBottomSheet,
     exit: exitSubmitButtonBottomSheet,
   } = useModal();
+  const { open: openMoreButtonBottomSheet, exit: exitMoreButtonBottomSheet } =
+    useModal();
+
+  useEffect(() => {
+    (async () => {
+      const data = await getFetch<NotionFolder>(url);
+      setData(data);
+    })();
+  }, [trigger]);
+
+  if (!data) {
+    return <></>;
+  }
+
   const openBottomSheetForNotionSubmit = (notion?: Notion) => {
     openSubmitButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet closeEvent={() => exitSubmitButtonBottomSheet()}>
         <NotionForm
+          notionFolderId={data.id}
           data={notion}
           subEvent={() => {
             setTrigger((trigger) => trigger + 1);
@@ -50,8 +65,6 @@ export default function Page({ params }: { params: { id: number } }) {
     ));
   };
 
-  const { open: openMoreButtonBottomSheet, exit: exitMoreButtonBottomSheet } =
-    useModal();
   const openBottomSheetForNotion = (notion: EssentialNotion) => {
     openMoreButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet size="free" closeEvent={() => exitMoreButtonBottomSheet()}>
@@ -79,39 +92,26 @@ export default function Page({ params }: { params: { id: number } }) {
     ));
   };
 
-  useEffect(() => {
-    (async () => {
-      const data = await getFetch<NotionFolder>(url);
-      setData(data.notions);
-    })();
-  }, [trigger]);
-
   return (
-    data && (
-      <main className="flex flex-col gap-5">
-        <Title content={data && data[0] ? data[0].name : 'empty...'} />
-        <CircleLine amount={8} />
-        <NotionList style="md:grid-cols-2 lg:grid-cols-3">
-          {data.map((item) => {
-            return (
-              <li key={item.name}>
-                <NotionItem
-                  content={item.name}
-                  handleMoreMenuButtonClick={() =>
-                    openBottomSheetForNotion(item)
-                  }
-                  handleNotionItemClick={() => handleNotionItemClick(item.id)}
-                />
-              </li>
-            );
-          })}
-          <li>
-            <PlusNotionButton
-              onClick={() => openBottomSheetForNotionSubmit()}
-            />
-          </li>
-        </NotionList>
-      </main>
-    )
+    <main className="flex flex-col gap-5">
+      <Title content={(data && data.name) ?? '무제'} />
+      <CircleLine amount={8} />
+      <NotionList style="md:grid-cols-2 lg:grid-cols-3">
+        {data.notions.map((item) => {
+          return (
+            <li key={item.name}>
+              <NotionItem
+                content={item.name}
+                handleMoreMenuButtonClick={() => openBottomSheetForNotion(item)}
+                handleNotionItemClick={() => handleNotionItemClick(item.id)}
+              />
+            </li>
+          );
+        })}
+        <li>
+          <PlusNotionButton onClick={() => openBottomSheetForNotionSubmit()} />
+        </li>
+      </NotionList>
+    </main>
   );
 }

--- a/app/folder/[id]/page.tsx
+++ b/app/folder/[id]/page.tsx
@@ -10,7 +10,7 @@ import { useMovePage } from 'hooks/useMovePage';
 
 import { GET_URL } from 'constants/url';
 import { getFetch } from 'utils/fetch';
-import { Notion } from 'types/notion';
+import { EssentialNotion, Notion, NotionFolder } from 'types/notion';
 import NotionItem from '@components/item/NotionItem';
 import PlusNotionButton from '@components/item/PlusNotionButton';
 import { useModal } from 'hooks/useModal';
@@ -21,12 +21,12 @@ import { deleteNotion } from 'utils/deleteNotion';
 import ButtonWithCircle from '@components/common/ButtonWithCircle';
 
 export default function Page({ params }: { params: { id: number } }) {
-  const [data, setData] = useState<Notion[]>();
+  const [data, setData] = useState<EssentialNotion[]>();
   const [trigger, setTrigger] = useState(0);
 
   const { moveNotionItemPage } = useMovePage();
 
-  const url = GET_URL.NOTION_LIST_IN_FOLDER(params.id);
+  const url = GET_URL.NOTION_FOLDER(params.id);
 
   const handleNotionItemClick = (id: number) => {
     moveNotionItemPage(id);
@@ -52,7 +52,7 @@ export default function Page({ params }: { params: { id: number } }) {
 
   const { open: openMoreButtonBottomSheet, exit: exitMoreButtonBottomSheet } =
     useModal();
-  const openBottomSheetForNotion = (notion: Notion) => {
+  const openBottomSheetForNotion = (notion: EssentialNotion) => {
     openMoreButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet size="free" closeEvent={() => exitMoreButtonBottomSheet()}>
         <div className="py-7 w-full">
@@ -81,8 +81,8 @@ export default function Page({ params }: { params: { id: number } }) {
 
   useEffect(() => {
     (async () => {
-      const data = await getFetch<Notion[]>(url);
-      setData(data);
+      const data = await getFetch<NotionFolder>(url);
+      setData(data.notions);
     })();
   }, [trigger]);
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
       <body>
         <ModalContext>
           <RecentlyNotionContext>
-            <div className="w-[95vw] sm:w-[90vw] md:w-[80vw] h-[90vh] mt-[2vh] sm:mt-[5vh] m-auto ">
+            <div className="w-[95vw] sm:w-[90vw] md:w-[80vw] h-fit my-[2vh] sm:my-[5vh] m-auto">
               <Navigation />
               {children}
             </div>

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -41,10 +41,42 @@ export default function Page({ params }: { params: { id: number } }) {
     open: openSubmitButtonBottomSheet,
     exit: exitSubmitButtonBottomSheet,
   } = useModal();
+
+  const {
+    open: openNotionMoreButtonBottomSheet,
+    exit: exitNotionMoreButtonBottomSheet,
+  } = useModal();
+
+  const {
+    open: openRelatedNotionMoreButtonBottomSheet,
+    exit: exitRelatedNotionMoreButtonBottomSheet,
+  } = useModal();
+
+  useEffect(() => {
+    (async () => {
+      const data = await getFetch<Notion>(url);
+      setData(data);
+      updateRecentlyNotionList(
+        { id: data.id, name: data.name },
+        data.id,
+        data.relatedNotions,
+      );
+      updateNowNotionFolder({
+        id: data.notionFolder.id,
+        name: data.notionFolder.name,
+      });
+    })();
+  }, [trigger]);
+
+  if (!data) {
+    return <></>;
+  }
+
   const openBottomSheetForNotionSubmit = (notion?: Notion) => {
     openSubmitButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet closeEvent={() => exitSubmitButtonBottomSheet()}>
         <NotionForm
+          notionFolderId={data.notionFolder.id}
           data={notion}
           relatedNotionId={params.id}
           subEvent={() => {
@@ -56,10 +88,6 @@ export default function Page({ params }: { params: { id: number } }) {
     ));
   };
 
-  const {
-    open: openNotionMoreButtonBottomSheet,
-    exit: exitNotionMoreButtonBottomSheet,
-  } = useModal();
   const openBottomSheetForNotion = (notion: Notion) => {
     openNotionMoreButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet
@@ -90,10 +118,6 @@ export default function Page({ params }: { params: { id: number } }) {
     ));
   };
 
-  const {
-    open: openRelatedNotionMoreButtonBottomSheet,
-    exit: exitRelatedNotionMoreButtonBottomSheet,
-  } = useModal();
   const openBottomSheetForRelatedNotion = (notion: EssentialNotion) => {
     openRelatedNotionMoreButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet
@@ -123,62 +147,42 @@ export default function Page({ params }: { params: { id: number } }) {
     ));
   };
 
-  useEffect(() => {
-    (async () => {
-      const data = await getFetch<Notion>(url);
-      setData(data);
-      updateRecentlyNotionList(
-        { id: data.id, name: data.name },
-        data.id,
-        data.relatedNotions,
-      );
-      updateNowNotionFolder({
-        id: data.notionFolder.id,
-        name: data.notionFolder.name,
-      });
-    })();
-  }, [trigger]);
-
   return (
-    data && (
-      <main className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-        <div className="flex flex-col gap-5">
-          <div className="flex flex-row justify-between">
-            <div className="flex flex-col gap-5">
-              <Title content={data.name} />
-              <CircleLine amount={8} />
-            </div>
-            <MoreMenuButton
-              direction="column"
-              size="sm"
-              onClick={() => openBottomSheetForNotion(data)}
-            />
+    <main className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-row justify-between">
+          <div className="flex flex-col gap-5">
+            <Title content={data.name} />
+            <CircleLine amount={8} />
           </div>
-          <div className="min-h-[150px]">
-            <Description content={data.content} />
-          </div>
+          <MoreMenuButton
+            direction="column"
+            size="sm"
+            onClick={() => openBottomSheetForNotion(data)}
+          />
         </div>
-        <NotionList>
-          {data.relatedNotions.map((item) => {
-            return (
-              <li key={item.name}>
-                <NotionItem
-                  content={item.name}
-                  handleMoreMenuButtonClick={() =>
-                    openBottomSheetForRelatedNotion(item)
-                  }
-                  handleNotionItemClick={() => handleNotionItemClick(item.id)}
-                />
-              </li>
-            );
-          })}
-          <li>
-            <PlusNotionButton
-              onClick={() => openBottomSheetForNotionSubmit()}
-            />
-          </li>
-        </NotionList>
-      </main>
-    )
+        <div className="min-h-[150px]">
+          <Description content={data.content} />
+        </div>
+      </div>
+      <NotionList>
+        {data.relatedNotions.map((item) => {
+          return (
+            <li key={item.name}>
+              <NotionItem
+                content={item.name}
+                handleMoreMenuButtonClick={() =>
+                  openBottomSheetForRelatedNotion(item)
+                }
+                handleNotionItemClick={() => handleNotionItemClick(item.id)}
+              />
+            </li>
+          );
+        })}
+        <li>
+          <PlusNotionButton onClick={() => openBottomSheetForNotionSubmit()} />
+        </li>
+      </NotionList>
+    </main>
   );
 }

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -132,27 +132,31 @@ export default function Page({ params }: { params: { id: number } }) {
         data.id,
         data.relatedNotions,
       );
-      //api에 지금 폴더 id가 없음
-      updateNowNotionFolder({ id: data.notionFolderId, name: '소속' });
+      updateNowNotionFolder({
+        id: data.notionFolder.id,
+        name: data.notionFolder.name,
+      });
     })();
   }, [trigger]);
 
   return (
     data && (
       <main className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-        <div className="flex flex-row justify-between">
-          <div className="flex flex-col gap-5">
-            <Title content={data.name} />
-            <CircleLine amount={8} />
+        <div className="flex flex-col gap-5">
+          <div className="flex flex-row justify-between">
+            <div className="flex flex-col gap-5">
+              <Title content={data.name} />
+              <CircleLine amount={8} />
+            </div>
+            <MoreMenuButton
+              direction="column"
+              size="sm"
+              onClick={() => openBottomSheetForNotion(data)}
+            />
           </div>
-          <MoreMenuButton
-            direction="column"
-            size="sm"
-            onClick={() => openBottomSheetForNotion(data)}
-          />
-        </div>
-        <div className="min-h-[150px]">
-          <Description content={data.content} />
+          <div className="min-h-[150px]">
+            <Description content={data.content} />
+          </div>
         </div>
         <NotionList>
           {data.relatedNotions.map((item) => {

--- a/app/notion/[id]/page.tsx
+++ b/app/notion/[id]/page.tsx
@@ -12,7 +12,7 @@ import { useMovePage } from 'hooks/useMovePage';
 
 import { GET_URL } from 'constants/url';
 import { getFetch } from 'utils/fetch';
-import { Notion, RelatedNotion } from 'types/notion';
+import { Notion, EssentialNotion } from 'types/notion';
 import NotionItem from '@components/item/NotionItem';
 import PlusNotionButton from '@components/item/PlusNotionButton';
 import { useModal } from 'hooks/useModal';
@@ -27,7 +27,8 @@ export default function Page({ params }: { params: { id: number } }) {
   const [data, setData] = useState<Notion>();
   const [trigger, setTrigger] = useState(0);
 
-  const { updateRecentlyNotionList } = useRecentlyNotionContext();
+  const { updateNowNotionFolder, updateRecentlyNotionList } =
+    useRecentlyNotionContext();
   const { moveNotionItemPage } = useMovePage();
 
   const url = GET_URL.NOTION_ITEM(params.id);
@@ -93,7 +94,7 @@ export default function Page({ params }: { params: { id: number } }) {
     open: openRelatedNotionMoreButtonBottomSheet,
     exit: exitRelatedNotionMoreButtonBottomSheet,
   } = useModal();
-  const openBottomSheetForRelatedNotion = (notion: RelatedNotion) => {
+  const openBottomSheetForRelatedNotion = (notion: EssentialNotion) => {
     openRelatedNotionMoreButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet
         size="free"
@@ -131,6 +132,8 @@ export default function Page({ params }: { params: { id: number } }) {
         data.id,
         data.relatedNotions,
       );
+      //api에 지금 폴더 id가 없음
+      updateNowNotionFolder({ id: data.notionFolderId, name: '소속' });
     })();
   }, [trigger]);
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,11 +20,13 @@ import FolderForm from '@components/item/FolderForm';
 import NotionInfo from '@components/item/NotionInfo';
 import { deleteNotionFolder } from 'utils/deleteNotion';
 import ButtonWithCircle from '@components/common/ButtonWithCircle';
+import { useRecentlyNotionContext } from '@components/context/RecentlyNotionContext';
 
 export default function Home() {
   const [data, setData] = useState<EssentialNotion[]>();
   const [trigger, setTrigger] = useState(0);
   const { moveNotionFolderItemListPage } = useMovePage();
+  const { resetAllData } = useRecentlyNotionContext();
 
   const {
     open: openSubmitButtonBottomSheet,
@@ -86,6 +88,7 @@ export default function Home() {
         GET_URL.NOTION_FOLDER_LIST(),
       );
 
+      resetAllData();
       setData(data);
     })();
   }, [trigger]);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import CircleLine from '@components/common/CircleLine';
 
 import { useMovePage } from 'hooks/useMovePage';
 
-import { NotionFolder } from 'types/notion';
+import { EssentialNotion } from 'types/notion';
 import { getFetch } from 'utils/fetch';
 import { GET_URL } from 'constants/url';
 import { useModal } from 'hooks/useModal';
@@ -22,7 +22,7 @@ import { deleteNotionFolder } from 'utils/deleteNotion';
 import ButtonWithCircle from '@components/common/ButtonWithCircle';
 
 export default function Home() {
-  const [data, setData] = useState<NotionFolder[]>();
+  const [data, setData] = useState<EssentialNotion[]>();
   const [trigger, setTrigger] = useState(0);
   const { moveNotionFolderItemListPage } = useMovePage();
 
@@ -31,7 +31,7 @@ export default function Home() {
     close: closeSubmitButtonBottomSheet,
     exit: exitSubmitButtonBottomSheet,
   } = useModal();
-  const openBottomSheetForNotionSubmit = (notionFolder?: NotionFolder) => {
+  const openBottomSheetForNotionSubmit = (notionFolder?: EssentialNotion) => {
     openSubmitButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet size="free" closeEvent={() => exitSubmitButtonBottomSheet()}>
         <div className="py-7 w-full">
@@ -53,7 +53,7 @@ export default function Home() {
     close: closeMoreButtonBottomSheet,
     exit: exitMoreButtonBottomSheet,
   } = useModal();
-  const openBottomSheetForNotion = (notionFolder: NotionFolder) => {
+  const openBottomSheetForNotion = (notionFolder: EssentialNotion) => {
     openMoreButtonBottomSheet(({ isOpen, close }) => (
       <BottomSheet size="free" closeEvent={() => exitMoreButtonBottomSheet()}>
         <div className="py-7 w-full">
@@ -82,7 +82,9 @@ export default function Home() {
 
   useEffect(() => {
     (async () => {
-      const data = await getFetch<NotionFolder[]>(GET_URL.NOTION_FOLDER_LIST());
+      const data = await getFetch<EssentialNotion[]>(
+        GET_URL.NOTION_FOLDER_LIST(),
+      );
 
       setData(data);
     })();

--- a/components/common/RoundSquare/index.tsx
+++ b/components/common/RoundSquare/index.tsx
@@ -17,6 +17,7 @@ const heightStyle: Record<Size | 'free', string> = {
 const colorInfo: Record<Color, string> = {
   default: 'bg-slate-100 hover:bg-slate-200',
   blue: 'bg-blue-300 hover:bg-blue-400',
+  lightBlue: 'bg-blue-100 hover:bg-blue-200',
   orange: 'bg-orange-300 hover:bg-orange-400',
   lightOrange: 'bg-orange-100 hover:bg-orange-200',
 };

--- a/components/context/RecentlyNotionContext.tsx
+++ b/components/context/RecentlyNotionContext.tsx
@@ -15,6 +15,7 @@ interface RecentlyNotionContextProps {
     nowNotionId: number,
     relationNotionList: EssentialNotion[],
   ) => void;
+  resetAllData: () => void;
 }
 
 const limitCount = 7;
@@ -29,6 +30,7 @@ export const recentlyNotionContext = createContext<RecentlyNotionContextProps>({
     nowNotionId: number,
     relationNotionList: EssentialNotion[],
   ) => {},
+  resetAllData: () => {},
 });
 
 export default function RecentlyNotionContext({
@@ -91,6 +93,11 @@ export default function RecentlyNotionContext({
     setNowNotionFolder(data);
   };
 
+  const resetAllData = () => {
+    setNowNotionFolder(null);
+    setRecentlyNotionList([]);
+  };
+
   return (
     <recentlyNotionContext.Provider
       value={{
@@ -98,6 +105,7 @@ export default function RecentlyNotionContext({
         updateNowNotionFolder,
         recentlyNotionList,
         updateRecentlyNotionList,
+        resetAllData,
       }}
     >
       {children}

--- a/components/context/RecentlyNotionContext.tsx
+++ b/components/context/RecentlyNotionContext.tsx
@@ -1,28 +1,33 @@
-import { createContext, useContext, useState } from 'react';
-import { NotionFolder } from 'types/notion';
+import { createContext, useContext, useMemo, useState } from 'react';
+import { EssentialNotion } from 'types/notion';
 import { Color } from 'types/style';
 
-interface ContextNotionInfo extends NotionFolder {
+interface ContextNotionInfo extends EssentialNotion {
   color: Color;
 }
 
 interface RecentlyNotionContextProps {
+  nowNotionFolder: EssentialNotion | null;
+  updateNowNotionFolder: (data: EssentialNotion) => void;
   recentlyNotionList: ContextNotionInfo[];
   updateRecentlyNotionList: (
-    notionForAdd: NotionFolder,
+    notionForAdd: EssentialNotion,
     nowNotionId: number,
-    relationNotionList: NotionFolder[],
+    relationNotionList: EssentialNotion[],
   ) => void;
 }
 
 const limitCount = 7;
 
 export const recentlyNotionContext = createContext<RecentlyNotionContextProps>({
+  nowNotionFolder: null,
+  updateNowNotionFolder: (data: EssentialNotion) => {},
   recentlyNotionList: [],
+
   updateRecentlyNotionList: (
-    notionForAdd: NotionFolder,
+    notionForAdd: EssentialNotion,
     nowNotionId: number,
-    relationNotionList: NotionFolder[],
+    relationNotionList: EssentialNotion[],
   ) => {},
 });
 
@@ -34,9 +39,11 @@ export default function RecentlyNotionContext({
   const [recentlyNotionList, setRecentlyNotionList] = useState<
     ContextNotionInfo[]
   >([]);
+  const [nowNotionFolder, setNowNotionFolder] =
+    useState<EssentialNotion | null>(null);
 
   const addNotionItem = (
-    notion: NotionFolder,
+    notion: EssentialNotion,
     notionList: ContextNotionInfo[],
   ): ContextNotionInfo[] => {
     const notOverlapList = notionList.filter(({ id }) => id !== notion.id);
@@ -52,7 +59,7 @@ export default function RecentlyNotionContext({
   const checkNotionRelation = (
     notionList: ContextNotionInfo[],
     nowNotionId: number,
-    relationNotionList: NotionFolder[],
+    relationNotionList: EssentialNotion[],
   ): ContextNotionInfo[] => {
     const relationNotionIdList = relationNotionList.map((notion) => notion.id);
 
@@ -67,9 +74,9 @@ export default function RecentlyNotionContext({
   };
 
   const updateRecentlyNotionList = (
-    notionForAdd: NotionFolder,
+    notionForAdd: EssentialNotion,
     nowNotionId: number,
-    relationNotionList: NotionFolder[],
+    relationNotionList: EssentialNotion[],
   ) => {
     setRecentlyNotionList(
       checkNotionRelation(
@@ -80,9 +87,18 @@ export default function RecentlyNotionContext({
     );
   };
 
+  const updateNowNotionFolder = (data: EssentialNotion) => {
+    setNowNotionFolder(data);
+  };
+
   return (
     <recentlyNotionContext.Provider
-      value={{ recentlyNotionList, updateRecentlyNotionList }}
+      value={{
+        nowNotionFolder,
+        updateNowNotionFolder,
+        recentlyNotionList,
+        updateRecentlyNotionList,
+      }}
     >
       {children}
     </recentlyNotionContext.Provider>

--- a/components/item/FolderForm/index.tsx
+++ b/components/item/FolderForm/index.tsx
@@ -5,7 +5,7 @@ import { NOTION_TITLE_AMOUNT } from 'constants/amountLimit';
 import { POST_URL } from 'constants/url';
 import React, { FormEventHandler, useState } from 'react';
 import {
-  NotionFolder,
+  EssentialNotion,
   Notion,
   RequestNotionForPost,
   RequestNotionFolder,
@@ -13,7 +13,7 @@ import {
 import { fetchWithoutGet } from 'utils/fetch';
 
 interface FolderFormProps {
-  data?: NotionFolder;
+  data?: EssentialNotion;
   subEvent?: () => void;
 }
 

--- a/components/item/Navigation/index.tsx
+++ b/components/item/Navigation/index.tsx
@@ -7,8 +7,9 @@ import RoundSquare from '@components/common/RoundSquare';
 import { useMovePage } from 'hooks/useMovePage';
 
 export default function Navigation() {
-  const { recentlyNotionList } = useRecentlyNotionContext();
-  const { moveMainPage, moveNotionItemPage } = useMovePage();
+  const { nowNotionFolder, recentlyNotionList } = useRecentlyNotionContext();
+  const { moveMainPage, moveNotionFolderItemListPage, moveNotionItemPage } =
+    useMovePage();
 
   return (
     <div className="overflow-x-auto overflow-y-hidden snap-x">
@@ -21,6 +22,16 @@ export default function Navigation() {
             홈페이지
           </button>
         </RoundSquare>
+        {nowNotionFolder && (
+          <RoundSquare size="free" color="lightBlue">
+            <button
+              className="w-max min-w-[80px] h-[30px] pl-2 pr-2 font-bold"
+              onClick={() => moveNotionFolderItemListPage(nowNotionFolder.id)}
+            >
+              {nowNotionFolder.name} 폴더
+            </button>
+          </RoundSquare>
+        )}
         {recentlyNotionList.map(({ id, name, color }) => {
           return (
             <Fragment key={id}>

--- a/components/item/NotionForm/NotionForm.stories.tsx
+++ b/components/item/NotionForm/NotionForm.stories.tsx
@@ -20,4 +20,4 @@ type Story = StoryObj<typeof meta>;
 /**
  * 기본 모형
  */
-export const Default: Story = {};
+export const Default: Story = { args: { notionFolderId: 1 } };

--- a/components/item/NotionForm/index.tsx
+++ b/components/item/NotionForm/index.tsx
@@ -15,6 +15,7 @@ import {
 import { fetchWithoutGet } from 'utils/fetch';
 
 interface NotionFormProps {
+  notionFolderId: number;
   data?: Notion;
   relatedNotionId?: number;
   subEvent?: () => void;
@@ -28,6 +29,7 @@ interface NotionFormProps {
  * 2. 노션 수정
  */
 export default function NotionForm({
+  notionFolderId,
   data,
   relatedNotionId,
   subEvent,
@@ -57,6 +59,7 @@ export default function NotionForm({
       const submitData: RequestNotionForPost = {
         name: title,
         content: content,
+        notionFolderId: notionFolderId,
         relatedNotion: {
           id: relatedNotionId ?? null,
         },

--- a/components/item/NotionInfo/index.tsx
+++ b/components/item/NotionInfo/index.tsx
@@ -1,9 +1,9 @@
-import { NotionFolder } from 'types/notion';
+import { EssentialNotion } from 'types/notion';
 import NotionItem from '../NotionItem';
 import { ReactNode } from 'react';
 
 interface NotionInfoProps {
-  notion: NotionFolder;
+  notion: EssentialNotion;
   handleNotionItemClick?: () => void;
   children?: ReactNode;
 }

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -6,8 +6,8 @@ export const GET_URL = {
   NOTION_ITEM: (id: number) => `${base}/notions/${id}`,
   NOTION_FOLDER_LIST_MOCK: () => `/notion-folders`,
   NOTION_FOLDER_LIST: () => `${base}/notion-folders`,
-  NOTION_LIST_IN_FOLDER_MOCK: () => `/notion-folders/:id/notions`,
-  NOTION_LIST_IN_FOLDER: (id: number) => `${base}/notion-folders/${id}/notions`,
+  NOTION_FOLDER_MOCK: () => `/notion-folders/:id`,
+  NOTION_FOLDER: (id: number) => `${base}/notion-folders/${id}`,
 };
 
 export const POST_URL = {

--- a/mocks/mockData/notion.ts
+++ b/mocks/mockData/notion.ts
@@ -3,7 +3,10 @@ import { Notion } from 'types/notion';
 export const mockNotionMonkey: Notion = {
   id: 1,
   name: '원숭이',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content:
     '원숭이 또는 잔나비는 영장류에 속하는 동물의 총칭이다. 원숭이하목은 크게 "신세계원숭이", "구세계원숭이", "유인원"으로 나뉜다. 신세계원숭이는 광비원소목을 이루지만, 구세계원숭이는 협비원소목의 한 상과에 그친다. 생김새와는 다르게, 분류학상으로는 인간과 훨씬 더 근연 관계에 있다.',
   relatedNotions: [
@@ -17,7 +20,10 @@ export const mockNotionMonkey: Notion = {
 export const mockNotionBananaMilk: Notion = {
   id: 2,
   name: '바나나맛 우유',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content:
     '바나나맛 우유(영어: Banana Flavored Milk)는 대한민국의 유제품 제조 회사 빙그레에서 1974년 6월에 출시한 바나나 가공유다. 1970년대 정부의 낙농업 육성을 위한 우유 소비 장려 정책에 힘입어 개발되었다. \n당시 고급과일의 대명사였던 바나나가 어린이들이 가장 먹고 싶어하는 과일이라는 점에 착안한 제품으로, 항아리 모양의 용기 디자인은 고향을 떠올리게 하기 위한 발상이었다. 당시에는 쥐기 힘들고 보관이 불편하다는 반대 의견도 있었다. \n독특한 용기 모양으로 단지우유 라는 애칭으로 불리며 하루 평균 80만개 이상, 연 2억 5만개 이상 판매되고 있다. 1998년 300억원, 2001년 600억원대의 매출을 기록한 데에 이어 가공유 제품으로는 사상 최초로 단일 브랜드로 연매출 1000억원대 기록을 달성했고, 2011년에는 연 1500억원의 매출을 기록했다. 가공유 시장에서 시장점유율 80%를 차지하고 있다. 2004년부터 미국, 캐나다, 중국 등 10여개 국가에 수출되고 있다. 국내 유제품 최초로 일본 시장에 진출해 편의점 로손의 8000개 점포에 입점했다. \n2006년 건강을 생각하는 젊은층을 타깃으로 지방함량을 1.5% 낮추고 당지수가 낮은 결정과당을 사용한 바나나맛 라이트가 출시된 데에 이어, 2012년 호두, 아몬드 등 견과류의 고소한 맛을 더한 "바나나맛 우유&토피넛"이 출시되었다. 바나나맛 우유&토피넛은 기존 제품과 동일한 용기 디자인에 브랜드 로고의 색깔이 다르다.2018년, "세상에 없던 우유" 시리즈 중 오디맛 우유를 출시했다.',
   relatedNotions: [
@@ -31,7 +37,10 @@ export const mockNotionBananaMilk: Notion = {
 export const mockNotionSnowWhite: Notion = {
   id: 3,
   name: '백설공주',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content:
     '살결이 매우 하얗게 태어난 백설 공주라 불리게 된 아이는 예쁜 얼굴과 고운 마음씨 때문에 사람들에게 사랑을 받고 자라지만, 어머니가 돌아가시고 새어머니를 맞으면서 이쁘다는 이유로 목숨을 위협당한다.',
   relatedNotions: [
@@ -45,7 +54,10 @@ export const mockNotionSnowWhite: Notion = {
 export const mockNotionBanana: Notion = {
   id: 4,
   name: '바나나',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content: '노랗고 달달한 더운 지역에서 재배되는 과일',
   relatedNotions: [
     {
@@ -66,7 +78,10 @@ export const mockNotionBanana: Notion = {
 export const mockNotionApple: Notion = {
   id: 5,
   name: '사과',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content: '빨갛고 동그란, 나무에 열리는 과실',
   relatedNotions: [
     {
@@ -83,7 +98,10 @@ export const mockNotionApple: Notion = {
 export const mockNotionSalmon: Notion = {
   id: 6,
   name: '연어',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content:
     '연어는 연어목 연어과에 속하는 어류이다. 또한 어린 연어는 연어사리라 부른다.',
   relatedNotions: [
@@ -97,7 +115,10 @@ export const mockNotionSalmon: Notion = {
 export const mockNotionBear: Notion = {
   id: 7,
   name: '곰',
-  notionFolderId: 1,
+  notionFolder: {
+    id: 1,
+    name: 'folder',
+  },
   content: '겨울잠을 자는 크고 힘이 쎈 동물',
   relatedNotions: [
     {

--- a/mocks/mockData/notion.ts
+++ b/mocks/mockData/notion.ts
@@ -3,6 +3,7 @@ import { Notion } from 'types/notion';
 export const mockNotionMonkey: Notion = {
   id: 1,
   name: '원숭이',
+  notionFolderId: 1,
   content:
     '원숭이 또는 잔나비는 영장류에 속하는 동물의 총칭이다. 원숭이하목은 크게 "신세계원숭이", "구세계원숭이", "유인원"으로 나뉜다. 신세계원숭이는 광비원소목을 이루지만, 구세계원숭이는 협비원소목의 한 상과에 그친다. 생김새와는 다르게, 분류학상으로는 인간과 훨씬 더 근연 관계에 있다.',
   relatedNotions: [
@@ -16,6 +17,7 @@ export const mockNotionMonkey: Notion = {
 export const mockNotionBananaMilk: Notion = {
   id: 2,
   name: '바나나맛 우유',
+  notionFolderId: 1,
   content:
     '바나나맛 우유(영어: Banana Flavored Milk)는 대한민국의 유제품 제조 회사 빙그레에서 1974년 6월에 출시한 바나나 가공유다. 1970년대 정부의 낙농업 육성을 위한 우유 소비 장려 정책에 힘입어 개발되었다. \n당시 고급과일의 대명사였던 바나나가 어린이들이 가장 먹고 싶어하는 과일이라는 점에 착안한 제품으로, 항아리 모양의 용기 디자인은 고향을 떠올리게 하기 위한 발상이었다. 당시에는 쥐기 힘들고 보관이 불편하다는 반대 의견도 있었다. \n독특한 용기 모양으로 단지우유 라는 애칭으로 불리며 하루 평균 80만개 이상, 연 2억 5만개 이상 판매되고 있다. 1998년 300억원, 2001년 600억원대의 매출을 기록한 데에 이어 가공유 제품으로는 사상 최초로 단일 브랜드로 연매출 1000억원대 기록을 달성했고, 2011년에는 연 1500억원의 매출을 기록했다. 가공유 시장에서 시장점유율 80%를 차지하고 있다. 2004년부터 미국, 캐나다, 중국 등 10여개 국가에 수출되고 있다. 국내 유제품 최초로 일본 시장에 진출해 편의점 로손의 8000개 점포에 입점했다. \n2006년 건강을 생각하는 젊은층을 타깃으로 지방함량을 1.5% 낮추고 당지수가 낮은 결정과당을 사용한 바나나맛 라이트가 출시된 데에 이어, 2012년 호두, 아몬드 등 견과류의 고소한 맛을 더한 "바나나맛 우유&토피넛"이 출시되었다. 바나나맛 우유&토피넛은 기존 제품과 동일한 용기 디자인에 브랜드 로고의 색깔이 다르다.2018년, "세상에 없던 우유" 시리즈 중 오디맛 우유를 출시했다.',
   relatedNotions: [
@@ -29,6 +31,7 @@ export const mockNotionBananaMilk: Notion = {
 export const mockNotionSnowWhite: Notion = {
   id: 3,
   name: '백설공주',
+  notionFolderId: 1,
   content:
     '살결이 매우 하얗게 태어난 백설 공주라 불리게 된 아이는 예쁜 얼굴과 고운 마음씨 때문에 사람들에게 사랑을 받고 자라지만, 어머니가 돌아가시고 새어머니를 맞으면서 이쁘다는 이유로 목숨을 위협당한다.',
   relatedNotions: [
@@ -42,6 +45,7 @@ export const mockNotionSnowWhite: Notion = {
 export const mockNotionBanana: Notion = {
   id: 4,
   name: '바나나',
+  notionFolderId: 1,
   content: '노랗고 달달한 더운 지역에서 재배되는 과일',
   relatedNotions: [
     {
@@ -62,6 +66,7 @@ export const mockNotionBanana: Notion = {
 export const mockNotionApple: Notion = {
   id: 5,
   name: '사과',
+  notionFolderId: 1,
   content: '빨갛고 동그란, 나무에 열리는 과실',
   relatedNotions: [
     {
@@ -78,6 +83,7 @@ export const mockNotionApple: Notion = {
 export const mockNotionSalmon: Notion = {
   id: 6,
   name: '연어',
+  notionFolderId: 1,
   content:
     '연어는 연어목 연어과에 속하는 어류이다. 또한 어린 연어는 연어사리라 부른다.',
   relatedNotions: [
@@ -91,6 +97,7 @@ export const mockNotionSalmon: Notion = {
 export const mockNotionBear: Notion = {
   id: 7,
   name: '곰',
+  notionFolderId: 1,
   content: '겨울잠을 자는 크고 힘이 쎈 동물',
   relatedNotions: [
     {

--- a/mocks/mockData/notionFolder.ts
+++ b/mocks/mockData/notionFolder.ts
@@ -1,3 +1,13 @@
+import { EssentialNotion, NotionFolder } from 'types/notion';
 import { mockNotionBear, mockNotionMonkey } from './notion';
 
-export const mockNotionFolder = [mockNotionMonkey, mockNotionBear];
+export const mockNotionFolderList: EssentialNotion[] = [
+  mockNotionMonkey,
+  mockNotionBear,
+];
+
+export const mockNotionFolder: NotionFolder = {
+  id: 1,
+  name: '원숭ㅇ이...?',
+  notions: [mockNotionMonkey, mockNotionBear],
+};

--- a/mocks/notionFolder.ts
+++ b/mocks/notionFolder.ts
@@ -1,10 +1,13 @@
 import { rest } from 'msw';
 import { DELETE_URL, GET_URL, POST_URL } from 'constants/url';
-import { mockNotionFolder } from './mockData/notionFolder';
+import {
+  mockNotionFolder,
+  mockNotionFolderList,
+} from './mockData/notionFolder';
 
 export const notionFolder = [
   rest.get(GET_URL.NOTION_FOLDER_LIST_MOCK(), (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(mockNotionFolder));
+    return res(ctx.status(200), ctx.json(mockNotionFolderList));
   }),
 
   rest.post(POST_URL.NOTION_FOLDER_MOCK(), (req, res, ctx) => {
@@ -17,7 +20,7 @@ export const notionFolder = [
 ];
 
 export const getNotionListInFolder = [
-  rest.get(GET_URL.NOTION_LIST_IN_FOLDER_MOCK(), (req, res, ctx) => {
+  rest.get(GET_URL.NOTION_FOLDER_MOCK(), (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(mockNotionFolder));
   }),
 ];

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -16,7 +16,10 @@ export interface EssentialNotion {
 export interface Notion {
   id: number;
   name: string;
-  notionFolderId: number;
+  notionFolder: {
+    id: number;
+    name: string;
+  };
   content: string;
   relatedNotions: EssentialNotion[];
 }

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -1,13 +1,14 @@
 export interface NotionFolder {
   id: number;
   name: string;
+  notions: EssentialNotion[];
 }
 
 export interface RequestNotionFolder {
   name: string;
 }
 
-export interface RelatedNotion {
+export interface EssentialNotion {
   id: number;
   name: string;
 }
@@ -15,8 +16,9 @@ export interface RelatedNotion {
 export interface Notion {
   id: number;
   name: string;
+  notionFolderId: number;
   content: string;
-  relatedNotions: RelatedNotion[];
+  relatedNotions: EssentialNotion[];
 }
 
 export interface RequestNotionForPost {

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -27,6 +27,7 @@ export interface Notion {
 export interface RequestNotionForPost {
   name: string;
   content: string;
+  notionFolderId: number;
   relatedNotion: {
     id: number | null;
   };

--- a/types/style.ts
+++ b/types/style.ts
@@ -1,2 +1,2 @@
 export type Size = 'sm' | 'md' | 'lg';
-export type Color = 'default' | 'blue' | 'orange' | 'lightOrange';
+export type Color = 'default' | 'blue' | 'lightBlue' | 'orange' | 'lightOrange';


### PR DESCRIPTION
## 🔥 연관 이슈

close: #27

<br/>

## 📝 작업 요약
- [x] 노션 get api에 소속 폴더 id 추가
- [x] 폴더 내 노션 리스트 get api를 폴더 정보 get api로 수정

<br/>

## ⏰ 소요 시간
1일

기능 구현에 소요된 시간을 적어주세요. (추정했던 시간과 다르다면 이유도 함께)

<br/>

## 🔎 작업 상세 설명
- 네비게이션 기능 수정
- api 수정
    - 폴더 get url 수정, 이름 수정, id, name 등 추가
    - 노션 get api 소속폴더 정보 필드 추가
    - 노션 post api 에 소속폴더 id 넣기

<br/>

## 🌟 참고 사항
- 에러처리/로딩처리 미완, 노션 페이지에서 노션 삭제하면 네비게이션 등 수정 필요

<br/>
